### PR TITLE
fix: continuous input text and drag-and-drop operations will be batched together

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seewo-doc/slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.88.1-beta.1",
+  "version": "0.88.1-beta.2",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seewo-doc/slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.88.1-beta.2",
+  "version": "0.88.1-beta.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -1261,8 +1261,6 @@ export const Editable = (props: EditableProps) => {
                   const range = ReactEditor.findEventRange(editor, event)
                   const data = event.dataTransfer
 
-                  Transforms.select(editor, range)
-
                   if (state.isDraggingInternally) {
                     if (
                       draggedRange &&
@@ -1274,6 +1272,8 @@ export const Editable = (props: EditableProps) => {
                       })
                     }
                   }
+
+                  Transforms.select(editor, range)
 
                   ReactEditor.insertData(editor, data)
 


### PR DESCRIPTION
**Description**
To address the issue of continuous input text and drag-and-drop operations being batched together, we swap the order of the "select" and "delete" actions in the "onDrop" function.

**Example**
continuous input text
![image](https://user-images.githubusercontent.com/21359263/218631704-0f765890-5a89-46c7-a4a4-3e4c0a6170b5.png)

the content is
![image](https://user-images.githubusercontent.com/21359263/218631758-697d01dd-f972-4409-a829-45bb4882a1fe.png)

then select "222"，drag and drop to 11111
the result is
![image](https://user-images.githubusercontent.com/21359263/218631937-c7f663cb-232c-43ec-871a-8921a19af8e0.png)

but the last batch of undos is
![image](https://user-images.githubusercontent.com/21359263/218632023-9e2d47e6-df92-4087-93ae-14a17b85aa74.png)

it will cause previously inserted text to be remove when execute the "undo"

