### PR TITLE
Fix android card element

### DIFF
--- a/.changeset/unlucky-chairs-promise.md
+++ b/.changeset/unlucky-chairs-promise.md
@@ -1,6 +1,0 @@
----
-"slate-react": patch
-"slate": patch
----
-
-Fix the cursor jump to an unexpected position after deleting in android

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seewo-doc/slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.88.1-beta.3",
+  "version": "0.88.1-beta.5",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -462,9 +462,9 @@ export function createAndroidInputManager({
           })
         }
 
-        return scheduleAction(() => Editor.deleteBackward(editor), {
-          at: targetRange,
-        })
+        scheduleFlush()
+        Editor.deleteBackward(editor)
+        return
       }
 
       case 'deleteEntireSoftLine': {
@@ -526,9 +526,9 @@ export function createAndroidInputManager({
       }
 
       case 'insertParagraph': {
-        return scheduleAction(() => Editor.insertBreak(editor), {
-          at: targetRange,
-        })
+        scheduleFlush()
+        Editor.insertBreak(editor)
+        return
       }
       case 'insertCompositionText':
       case 'deleteCompositionText':


### PR DESCRIPTION
修复 Android 下，insertBreak 和 deleteBackward 事件没有及时触发，导致业务实现的卡片元素，无法对相应的事件进行拦截