### PR TITLE
Fix android void element can be input

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seewo-doc/slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.88.1-beta.5",
+  "version": "0.88.1-beta.6",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -352,12 +352,25 @@ export function createAndroidInputManager({
       insertPositionHint = false
     }
 
+    let inVoidNode = false
     let [nativeTargetRange] = (event as any).getTargetRanges()
     if (nativeTargetRange) {
       targetRange = ReactEditor.toSlateRange(editor, nativeTargetRange, {
         exactMatch: false,
         suppressThrow: true,
       })
+
+      if (
+        nativeTargetRange.collapsed &&
+        nativeTargetRange.startContainer.nodeType === globalThis.Node.TEXT_NODE
+      ) {
+        const closestElement = nativeTargetRange.startContainer.parentElement.closest(
+          '[data-slate-node=element]'
+        )
+        inVoidNode = closestElement?.attributes.hasOwnProperty(
+          'data-slate-void'
+        )
+      }
     }
 
     // COMPAT: SelectionChange event is fired after the action is performed, so we
@@ -520,12 +533,14 @@ export function createAndroidInputManager({
       }
 
       case 'insertLineBreak': {
+        if (inVoidNode) return
         return scheduleAction(() => Editor.insertSoftBreak(editor), {
           at: targetRange,
         })
       }
 
       case 'insertParagraph': {
+        if (inVoidNode) return
         scheduleFlush()
         Editor.insertBreak(editor)
         return
@@ -538,6 +553,7 @@ export function createAndroidInputManager({
       case 'insertFromYank':
       case 'insertReplacementText':
       case 'insertText': {
+        if (inVoidNode) return
         if (data?.constructor.name === 'DataTransfer') {
           return scheduleAction(() => ReactEditor.insertData(editor, data), {
             at: targetRange,


### PR DESCRIPTION
**Description**

由于 android 下 void 元素无法聚焦弹出键盘，需要将 contenteditable 设置为 true，由此导致元素中的 zero width node 可以被输入文本。需要在 beforeInput 事件中，阻止此行为。

https://user-images.githubusercontent.com/11460856/219865805-07032858-cc8b-4daa-8f30-09b06be1d26a.mp4
