### PR TITLE
Fix android get target ranges

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seewo-doc/slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.88.1-beta.7",
+  "version": "0.88.1-beta.8",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seewo-doc/slate-react",
   "description": "Tools for building completely customizable richtext editors with React.",
-  "version": "0.88.1-beta.6",
+  "version": "0.88.1-beta.7",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "dist/index.js",

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -377,7 +377,16 @@ export function createAndroidInputManager({
     // have to manually get the selection here to ensure it's up-to-date.
     const window = ReactEditor.getWindow(editor)
     const domSelection = window.getSelection()
-    if (!targetRange && domSelection) {
+
+    // 通过非手动方式（比如删除）定位到卡片光标初时，getTargetRanges 获取到的值不正确
+    const forceUseDomSelection =
+      editor.selection &&
+      Range.isCollapsed(editor.selection) &&
+      editor.selection.focus.offset < 0 &&
+      nativeTargetRange &&
+      !nativeTargetRange.isCollapsed
+
+    if ((!targetRange || forceUseDomSelection) && domSelection) {
       nativeTargetRange = domSelection
       targetRange = ReactEditor.toSlateRange(editor, domSelection, {
         exactMatch: false,

--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -367,7 +367,7 @@ export function createAndroidInputManager({
         const closestElement = nativeTargetRange.startContainer.parentElement.closest(
           '[data-slate-node=element]'
         )
-        inVoidNode = closestElement?.attributes.hasOwnProperty(
+        inVoidNode = !!closestElement?.attributes.hasOwnProperty(
           'data-slate-void'
         )
       }
@@ -590,6 +590,11 @@ export function createAndroidInputManager({
             start: start.offset,
             end: end.offset,
             text,
+          }
+
+          if (targetRange.anchor.offset < 0) {
+            Editor.insertText(editor, text)
+            return
           }
 
           // COMPAT: Swiftkey has a weird bug where the target range of the 2nd word


### PR DESCRIPTION
1.修复安卓下，正确设置了 window.selection 但从 event.getTargetRanges 获取到的选区值可能不正确的问题
![image](https://user-images.githubusercontent.com/11460856/220654631-fc3d6a2f-ffb9-4b01-8ed3-667856edabb9.png)

2.修复安卓下，在卡片元素光标位置进行输入，没有触发卡片元素的 editor.insertText 逻辑