### PR TITLE
Disable text input for nodes with data-slate-text-void=true attribute

### DIFF
--- a/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/slate-react/src/hooks/android-input-manager/android-input-manager.ts
@@ -365,6 +365,11 @@ export function createAndroidInputManager({
         suppressThrow: true,
       })
 
+      if (nativeTargetRange.startContainer.nodeType === globalThis.Node.TEXT_NODE) {
+        const closestVoidText = nativeTargetRange.startContainer.parentElement.closest('[data-slate-text-void=true]')
+        inVoidNode = !!closestVoidText
+      }
+
       if (
         nativeTargetRange.collapsed &&
         nativeTargetRange.startContainer.nodeType === globalThis.Node.TEXT_NODE
@@ -372,7 +377,7 @@ export function createAndroidInputManager({
         const closestElement = nativeTargetRange.startContainer.parentElement.closest(
           '[data-slate-node=element]'
         )
-        inVoidNode = !!closestElement?.attributes.hasOwnProperty(
+        inVoidNode = inVoidNode || !!closestElement?.attributes.hasOwnProperty(
           'data-slate-void'
         )
       }


### PR DESCRIPTION
**Description**

安卓下点击带蒙层的文本无法弹起键盘，需要设置`contenteditor="true"`，但这样会让文本允许编辑。因此需要新增`data-slate-text-void="true"`空文本标识，并在安卓端阻止文本输入

https://github.com/seewo-doc/slate/assets/56380896/ab27294a-b7a7-4f76-802a-31dc436c6121

